### PR TITLE
add Matthew Blode (matthewblode.com)

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -1,5 +1,13 @@
 [
   {
+    "url": "https://matthewblode.com",
+    "title": "Matthew Blode",
+    "about": "https://matthewblode.com/about",
+    "feed": "https://matthewblode.com/feed.xml",
+    "desc": "Essays on building products, shipping with AI, and developer craft from a Melbourne-based product engineer at Linktree.",
+    "hn": []
+  },
+  {
     "url": "https://taylor.town",
     "title": "Taylor Troesh",
     "about": "https://taylor.town/about",


### PR DESCRIPTION
Adding my blog to the directory. Personal site + blog of a Melbourne-based product engineer on the AI team at Linktree, with an RSS feed at /feed.xml. Thanks!